### PR TITLE
RKTRUST: RK3399TRUST: Fix image paths

### DIFF
--- a/RKTRUST/RK3399TRUST.ini
+++ b/RKTRUST/RK3399TRUST.ini
@@ -5,11 +5,11 @@ MINOR=0
 SEC=0
 [BL31_OPTION]
 SEC=1
-PATH=tools/rk_tools/bin/rk33/rk3399_bl31_v1.26.elf
+PATH=bin/rk33/rk3399_bl31_v1.26.elf
 ADDR=0x00010000
 [BL32_OPTION]
 SEC=1
-PATH=tools/rk_tools/bin/rk33/rk3399_bl32_v1.16.bin
+PATH=bin/rk33/rk3399_bl32_v1.16.bin
 ADDR=0x08400000
 [BL33_OPTION]
 SEC=0


### PR DESCRIPTION
When trust_merger is run, it is checking bl3* images in tools directory,
which is incorrect. The bl3* binaries are present in bin/ directory
so fix this.

Here are the Error logs

$ ./tools/trust_merger RKTRUST/RK3399TRUST.ini
out:trust.img
E: [mergetrust] filter_elf tools/rk_tools/bin/rk33/rk3399_bl31_v1.25.elf file failed
merge failed!

$ ./tools/trust_merger RKTRUST/RK3399TRUST.ini
out:trust.img
E: [mergetrust] filter_elf tools/rk_tools/bin/rk33/rk3399_bl32_v1.16.bin file failed
merge failed!

Signed-off-by: Shyam Saini <shyam.saini@amarulasolutions.com>